### PR TITLE
PRIMUS_output.log not always being created 

### DIFF
--- a/bin/primus_kickoff7.pl
+++ b/bin/primus_kickoff7.pl
@@ -117,6 +117,14 @@ my $public_html_dir = "/nfs/home/grapas2/public_html";
 
 ## Process command line options.
 apply_options();
+
+if(-d $output_dir) # The output directory exist we are going to rename
+{
+	system("mv $output_dir $output_dir\_OLD");	
+} 
+# Then we need to create the direcotry to output to
+make_path($output_dir) if !-d $output_dir;
+
 open($LOG,">$log_file") if($LOG eq "");
 
 print $LOG "Commandline options used: @commandline_options\n";


### PR DESCRIPTION
# Issue:
--------
On several of my PRIMUS runs, the PRIMUS_output.log file was not being created. My runs were failing (for other reasons on my part) and I was hoping I could look at the log file but it was never made. I realized this issue was occurring only when I would rerun primus without removing the output directory from the previous run. 

# Explanation :
--------------
I think what is happening is that when PRIMUS renames the previous output directory, the $LOG filehandle gets shut accidentally and then there is no where but stdout for the logging messages to go to. This would also explain the several warning messages that I was receiving about writing to a closed file see issue #1.

# Code change:
----------------
This code moves the part of primus_kickoff7.pl that checks for the previous output directory (previous lines 129-132) to lines 121-124 above the open($LOG, ...) statement. Then I added additional code to create the output directory if it doesn't already exist to line 126. I'm sure that line 126 introduces redundancy but the if statement makes sure that it will not try to recreate an already existing directory. This change ensures that the output directory is made and fixes issue #1
